### PR TITLE
Set the default repository path to same as file

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,6 @@ Clone the git repository:
 git clone https://github.com/fredrikaverpil/pyvfx-boilerplate.git
 ```
 
-Edit `boilerplate.py` to make the `REPO_PATH` point to the location where you cloned the repository.
-
 <br>
 
 #### Example usage

--- a/boilerplate.py
+++ b/boilerplate.py
@@ -49,7 +49,7 @@ DOCK_WITH_MAYA_UI = False
 DOCK_WITH_NUKE_UI = False
 
 # Repository path
-REPO_PATH = '/Users/fredrik/code/repos/pyvfx-boilerplate/'
+REPO_PATH = os.path.dirname(__file__)
 
 # Palette filepath
 PALETTE_FILEPATH = os.path.join(


### PR DESCRIPTION
By using `__file__` to get the path to `boilerplate.py`, and getting the base folder from `os.path.dirname`, `REPO_PATH` can be automatically set to the correct location without any editing required.